### PR TITLE
Make Utterances comment widget configurable via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ pnpm dev
 pnpm build
 ```
 
+## Configuración de Comentarios (Utterances)
+
+El sistema de comentarios se basa en [Utterances](https://utteranc.es/). Para que funcione en producción debes:
+
+1. Contar con un repositorio público en GitHub y tener instalada la aplicación de Utterances sobre él.
+2. (Opcional) Crear la etiqueta que quieras aplicar a los issues antes de especificarla.
+3. Definir las siguientes variables de entorno (por ejemplo, en Netlify) según necesites:
+
+| Variable | Descripción | Valor por defecto |
+| --- | --- | --- |
+| `VITE_UTTERANCES_REPO` | Repositorio donde se guardarán los comentarios. | `CaldeIsa/catalogo-pinturas-comentarios` |
+| `VITE_UTTERANCES_ISSUE_TERM` | Estrategia para mapear comentarios (ej. `pathname`, `url`). | `pathname` |
+| `VITE_UTTERANCES_LABEL` | Etiqueta opcional para los issues. Debe existir previamente en el repositorio. | *(sin etiqueta)* |
+| `VITE_UTTERANCES_THEME` | Tema visual del widget (`github-light`, `github-dark`, etc.). | `github-light` |
+
+Si la etiqueta configurada no existe en el repositorio, GitHub devolverá un error `422` y los comentarios no se crearán. Deja la variable vacía si no deseas asignar etiquetas.
+
 ## Estructura del Proyecto
 
 ```

--- a/client/src/components/Comments.tsx
+++ b/client/src/components/Comments.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useRef } from "react";
 
+import {
+  UTTERANCES_ISSUE_TERM,
+  UTTERANCES_LABEL,
+  UTTERANCES_REPO,
+  UTTERANCES_THEME,
+} from "@/const";
+
 interface CommentsProps {
   title?: string;
   description?: string;
@@ -9,26 +16,30 @@ export default function Comments({ title = "Comentarios", description = "" }: Co
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!containerRef.current || !UTTERANCES_REPO) return;
 
-    // Crear el script de Utterances con atributos adicionales
+    const container = containerRef.current;
+    container.innerHTML = "";
+
     const script = document.createElement("script");
     script.src = "https://utteranc.es/client.js";
     script.async = true;
     script.crossOrigin = "anonymous";
-    
-    // Configuración de Utterances
-    script.setAttribute("repo", "CaldeIsa/catalogo-pinturas-comentarios");
-    script.setAttribute("issue-term", "pathname");
-    script.setAttribute("theme", "light");
-    script.setAttribute("label", "comments");
+    script.setAttribute("repo", UTTERANCES_REPO);
+    script.setAttribute("issue-term", UTTERANCES_ISSUE_TERM);
+    script.setAttribute("theme", UTTERANCES_THEME);
     script.setAttribute("loading", "lazy");
 
-    // Limpiar contenido previo
-    containerRef.current.innerHTML = "";
-    
-    // Agregar el script
-    containerRef.current.appendChild(script);
+    if (UTTERANCES_LABEL) {
+      script.setAttribute("label", UTTERANCES_LABEL);
+    }
+
+    script.onerror = () => {
+      container.innerHTML =
+        "<p class=\"text-sm text-muted-foreground\">No se pudo cargar el sistema de comentarios. Verifica la configuración de Utterances.</p>";
+    };
+
+    container.appendChild(script);
   }, []);
 
   return (

--- a/client/src/const.ts
+++ b/client/src/const.ts
@@ -19,3 +19,14 @@ export const getLoginUrl = () => {
 
   return url.toString();
 };
+
+export const UTTERANCES_REPO =
+  import.meta.env.VITE_UTTERANCES_REPO || "CaldeIsa/catalogo-pinturas-comentarios";
+
+export const UTTERANCES_ISSUE_TERM =
+  import.meta.env.VITE_UTTERANCES_ISSUE_TERM || "pathname";
+
+export const UTTERANCES_LABEL = import.meta.env.VITE_UTTERANCES_LABEL?.trim() || undefined;
+
+export const UTTERANCES_THEME =
+  import.meta.env.VITE_UTTERANCES_THEME || "github-light";


### PR DESCRIPTION
## Summary
- allow configuring the Utterances widget with environment-driven repo, term, label, and theme values
- add a graceful error message when the Utterances script cannot be loaded
- document the production environment variables needed to enable the comments feature

## Testing
- pnpm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114c548478833196e7d8c0a3696c1b)